### PR TITLE
feat: use cached network image

### DIFF
--- a/lib/presentation/widgets/common/optimized_image.dart
+++ b/lib/presentation/widgets/common/optimized_image.dart
@@ -1,5 +1,17 @@
-import 'package:flutter/material.dart';
 import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+/// Administrador de cache personalizado para controlar el tamaño y periodo de validez
+final CacheManager _customCacheManager = CacheManager(
+  Config(
+    'optimizedImageCache',
+    stalePeriod: const Duration(days: 7),
+    maxNrOfCacheObjects: 100,
+  ),
+);
 
 /// Widget optimizado para mostrar imágenes con cache y manejo de errores
 /// Previene reconstrucciones innecesarias y mejora el rendimiento
@@ -75,20 +87,16 @@ class _OptimizedImageState extends State<OptimizedImage>
   }
 
   Widget _buildNetworkImage() {
-    return Image.network(
-      widget.imageUrl!,
+    return CachedNetworkImage(
+      imageUrl: widget.imageUrl!,
       width: widget.width,
       height: widget.height,
       fit: widget.fit,
-      cacheWidth: widget.cacheWidth.toInt(),
-      cacheHeight: widget.cacheHeight.toInt(),
-      loadingBuilder: (context, child, loadingProgress) {
-        if (loadingProgress == null) return child;
-        return _buildPlaceholder();
-      },
-      errorBuilder: (context, error, stackTrace) {
-        return _buildErrorWidget();
-      },
+      placeholder: (context, url) => _buildPlaceholder(),
+      errorWidget: (context, url, error) => _buildErrorWidget(),
+      cacheManager: _customCacheManager,
+      memCacheWidth: widget.cacheWidth.toInt(),
+      memCacheHeight: widget.cacheHeight.toInt(),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   animations: ^2.0.11
   shimmer: ^3.0.0
   flutter_svg: ^2.0.9
+  cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
 
   # Other - actualizados
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- add cached_network_image and flutter_cache_manager dependencies
- use CachedNetworkImage in OptimizedImage with placeholder and error handling
- introduce custom CacheManager for cache size control

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a1322b6a08326b4af88545b256f7e