### PR TITLE
refactor: apply themed text styles in home page

### DIFF
--- a/lib/core/themes/app_theme.dart
+++ b/lib/core/themes/app_theme.dart
@@ -226,12 +226,12 @@ class AppTheme {
         ),
         headlineMedium: GoogleFonts.inter(
           fontSize: 20,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.bold,
           color: textPrimary,
         ),
         headlineSmall: GoogleFonts.inter(
           fontSize: 18,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.bold,
           color: textPrimary,
         ),
         titleLarge: GoogleFonts.inter(
@@ -263,6 +263,11 @@ class AppTheme {
           fontSize: 12,
           fontWeight: FontWeight.normal,
           color: textTertiary,
+        ),
+        labelMedium: GoogleFonts.inter(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: textPrimary,
         ),
       ),
     );
@@ -364,7 +369,7 @@ class AppTheme {
         ),
         headlineSmall: GoogleFonts.inter(
           fontSize: 18,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.bold,
           color: Colors.white,
         ),
         titleLarge: GoogleFonts.inter(
@@ -396,6 +401,11 @@ class AppTheme {
           fontSize: 12,
           fontWeight: FontWeight.normal,
           color: const Color(0xFF94A3B8), // Gris más suave para texto terciario
+        ),
+        labelMedium: GoogleFonts.inter(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: Colors.white,
         ),
       ),
       

--- a/lib/presentation/pages/home/home_page.dart
+++ b/lib/presentation/pages/home/home_page.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:go_router/go_router.dart';
 
@@ -187,18 +186,11 @@ class _HomePageState extends State<HomePage>
                 children: [
                   Text(
                     '¡Hola, ${state.user.name.split(' ').first}!',
-                    style: GoogleFonts.inter(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                 color: AppTheme.getTextPrimary(context),
-                    ),
+                    style: Theme.of(context).textTheme.headlineSmall,
                   ),
                   Text(
                     '¿Qué servicio necesitas hoy?',
-                     style: GoogleFonts.inter(
-                      fontSize: 14,
-                       color: AppTheme.getTextSecondary(context),
-                    ),
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
               ),
@@ -251,18 +243,11 @@ class _HomePageState extends State<HomePage>
                 children: [
                   Text(
                     '¡Hola!',
-                    style: GoogleFonts.inter(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                      color: AppTheme.textPrimary,
-                    ),
+                    style: Theme.of(context).textTheme.headlineSmall,
                   ),
                   Text(
                     '¿Qué servicio necesitas hoy?',
-                    style: GoogleFonts.inter(
-                      fontSize: 14,
-                      color: AppTheme.textSecondary,
-                    ),
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
               ),
@@ -307,10 +292,10 @@ class _HomePageState extends State<HomePage>
                 Expanded(
                   child: Text(
                     'Buscar servicios...',
-                    style: GoogleFonts.inter(
-                      fontSize: 16,
-                      color: AppTheme.getTextTertiary(context),
-                    ),
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyLarge
+                        ?.copyWith(color: AppTheme.getTextTertiary(context)),
                   ),
                 ),
               ],
@@ -333,11 +318,7 @@ class _HomePageState extends State<HomePage>
             children: [
               Text(
                 'Categorías',
-                style: GoogleFonts.inter(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  color: AppTheme.textPrimary,
-                ),
+                style: Theme.of(context).textTheme.headlineMedium,
               ),
               const SizedBox(height: 16),
             ],
@@ -402,11 +383,7 @@ class _HomePageState extends State<HomePage>
               const SizedBox(height: 8),
               Text(
                 category['name'],
-                style: GoogleFonts.inter(
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                  color: AppTheme.getTextPrimary(context),
-                ),
+                style: Theme.of(context).textTheme.labelMedium,
                 textAlign: TextAlign.center,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
@@ -461,11 +438,7 @@ class _HomePageState extends State<HomePage>
                   children: [
                     Text(
                       'Servicios Destacados',
-                      style: GoogleFonts.inter(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        color: AppTheme.textPrimary,
-                      ),
+                      style: Theme.of(context).textTheme.headlineMedium,
                     ),
                     if (state is HomeLoading)
                       const SizedBox(
@@ -507,10 +480,7 @@ class _HomePageState extends State<HomePage>
             const SizedBox(height: 8),
             Text(
               'Error al cargar servicios',
-              style: GoogleFonts.inter(
-                color: AppTheme.textSecondary,
-                fontSize: 14,
-              ),
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 8),
             TextButton(
@@ -529,10 +499,7 @@ class _HomePageState extends State<HomePage>
         return Center(
           child: Text(
             'No hay servicios disponibles',
-            style: GoogleFonts.inter(
-              color: AppTheme.textSecondary,
-              fontSize: 14,
-            ),
+            style: Theme.of(context).textTheme.bodyMedium,
           ),
         );
       }
@@ -576,11 +543,7 @@ class _HomePageState extends State<HomePage>
               children: [
                 Text(
                   'Cerca de ti',
-                  style: GoogleFonts.inter(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: AppTheme.textPrimary,
-                  ),
+                  style: Theme.of(context).textTheme.headlineMedium,
                 ),
                 const SizedBox(height: 16),
                 _buildNearbyServicesList(state),
@@ -611,10 +574,7 @@ class _HomePageState extends State<HomePage>
             const SizedBox(height: 8),
             Text(
               'Error al cargar servicios cercanos',
-              style: GoogleFonts.inter(
-                color: AppTheme.textSecondary,
-                fontSize: 14,
-              ),
+              style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 8),
             TextButton(
@@ -633,10 +593,7 @@ class _HomePageState extends State<HomePage>
         return Center(
           child: Text(
             'No hay servicios cercanos disponibles',
-            style: GoogleFonts.inter(
-              color: AppTheme.textSecondary,
-              fontSize: 14,
-            ),
+            style: Theme.of(context).textTheme.bodyMedium,
           ),
         );
       }


### PR DESCRIPTION
## Summary
- use bold headline and label styles in AppTheme text themes
- refactor home page texts to use Theme.of(context).textTheme

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a138010408326b51948d304ece50a